### PR TITLE
Search user chunks display

### DIFF
--- a/app/api/profiles/getChunks/route.ts
+++ b/app/api/profiles/getChunks/route.ts
@@ -23,13 +23,6 @@ export async function GET(request: NextRequest) {
       return NextResponse.json({ error: "User ID required" }, { status: 401 });
     }
 
-    if (userId !== user.id) {
-      return NextResponse.json(
-        { error: "Unauthorized access to user chunks" },
-        { status: 403 }
-      );
-    }
-
     const { data: chunks, error } = await supabase
       .from("user_files")
       .select("*")

--- a/app/search/SearchPageContent.tsx
+++ b/app/search/SearchPageContent.tsx
@@ -99,7 +99,7 @@ export default function SearchPageContent() {
     if (selectedUser?.chunkLoading) {
       fetchChunks();
     }
-  }, [selectedUser?.id, selectedUser?.chunkLoading]);
+  }, [selectedUser?.id, selectedUser?.chunkLoading, makeAuthenticatedRequest]);
 
   // Custom hooks for cleaner logic separation
   const { subscribeToChatroom, unsubscribe } = useRealtimeSubscription({

--- a/app/search/SearchPageContent.tsx
+++ b/app/search/SearchPageContent.tsx
@@ -6,11 +6,12 @@ import { CubeLoader } from "@/components/ui/CubeLoader";
 import MessageList from "@/components/search/MessageList";
 import SearchInput from "@/components/search/SearchInput";
 import ShareButton from "@/components/search/ShareButton";
-import { UserProfile } from "@/components/search/UserProfile";
+import { UserProfile } from "@/components/search/UserProfile/UserProfile";
 import { useAuthStore } from "@/stores/authStore";
 import { useRealtimeSubscription } from "@/components/search/hooks/useRealtimeSubscription";
 import { useChatroomData } from "@/components/search/hooks/useChatroomData";
 import { useSearch } from "@/components/search/hooks/useSearch";
+import { ChunkData } from "@/components/profile/chunks/ChunkUtils";
 
 interface SearchResults {
   result: string;
@@ -45,12 +46,18 @@ export default function SearchPageContent() {
     location?: string;
     tldr?: string;
     avatar?: string;
+    chunks?: ChunkData[];
+    chunkLoading?: boolean;
   } | null>(null);
   const [profileOpen, setProfileOpen] = useState(false);
   const [chatroomId, setChatroomId] = useState<string | null>(null);
   const [allMessages, setAllMessages] = useState<ChatMessage[]>([]);
 
-  const { user, loading: isAuthLoading } = useAuthStore();
+  const {
+    user,
+    loading: isAuthLoading,
+    makeAuthenticatedRequest,
+  } = useAuthStore();
   const searchParams = useSearchParams();
   const chatroomParam = mounted ? searchParams?.get("chatroom") || "" : "";
 
@@ -63,9 +70,36 @@ export default function SearchPageContent() {
     tldr?: string;
     avatar?: string;
   }) => {
-    setSelectedUser(user);
+    setSelectedUser({ ...user, chunkLoading: true, chunks: [] });
     setProfileOpen(true);
   };
+
+  // Fetch chunks when selectedUser changes
+  useEffect(() => {
+    const fetchChunks = async () => {
+      if (!selectedUser?.id) return;
+      try {
+        const res = await makeAuthenticatedRequest(
+          `/api/profiles/getChunks?userId=${selectedUser.id}`
+        );
+        if (!res.ok) throw new Error("Failed to fetch chunks");
+        const data = await res.json();
+        setSelectedUser((prev) =>
+          prev
+            ? { ...prev, chunks: data.chunks || [], chunkLoading: false }
+            : prev
+        );
+      } catch (err) {
+        console.error("Error fetching user chunks:", err);
+        setSelectedUser((prev) =>
+          prev ? { ...prev, chunks: [], chunkLoading: false } : prev
+        );
+      }
+    };
+    if (selectedUser?.chunkLoading) {
+      fetchChunks();
+    }
+  }, [selectedUser?.id, selectedUser?.chunkLoading]);
 
   // Custom hooks for cleaner logic separation
   const { subscribeToChatroom, unsubscribe } = useRealtimeSubscription({

--- a/components/search/MessageThread.tsx
+++ b/components/search/MessageThread.tsx
@@ -3,7 +3,7 @@ import { motion } from "framer-motion";
 import { CubeLoader } from "@/components/ui/CubeLoader";
 import { useUserProfiles } from "./hooks/useUserProfiles";
 import MatchResults from "./MatchResults";
-import PeopleSection from "./PeopleSection";
+import PeopleList from "./PeopleSection";
 
 interface SearchResults {
   result: string;
@@ -175,7 +175,7 @@ function CompletedResponse({
       </motion.p>
 
       {/* People section */}
-      <PeopleSection
+      <PeopleList
         isVisible={content.matches && content.matches.length > 0}
         searchMatches={content.matches}
         onUserClick={onUserClick || (() => {})}

--- a/components/search/PeopleSection.tsx
+++ b/components/search/PeopleSection.tsx
@@ -3,7 +3,7 @@ import { motion } from "framer-motion";
 import { ProfileCard } from "./ProfileCard";
 import { useUserProfiles } from "./hooks/useUserProfiles";
 
-interface PeopleSectionProps {
+interface PeopleListProps {
   isVisible: boolean;
   searchMatches?: {
     user_id: string;
@@ -21,11 +21,11 @@ interface PeopleSectionProps {
   }) => void;
 }
 
-export default function PeopleSection({
+export default function PeopleList({
   isVisible,
   searchMatches = [],
   onUserClick,
-}: PeopleSectionProps) {
+}: PeopleListProps) {
   // Extract user IDs from search matches
   const userIds = searchMatches.map((match) => match.user_id);
 

--- a/components/search/UserProfile/CategoryChunks.tsx
+++ b/components/search/UserProfile/CategoryChunks.tsx
@@ -1,0 +1,26 @@
+import { motion } from "framer-motion";
+import type { ChunkData } from "@/components/profile/chunks/ChunkUtils";
+
+interface CategoryChunksProps {
+  chunks: ChunkData[];
+}
+
+export function CategoryChunks({ chunks }: CategoryChunksProps) {
+  return (
+    <div className="pt-4 space-y-4">
+      {chunks
+        .filter((chunk) => chunk.status === "completed")
+        .map((chunk, idx) => (
+          <motion.div
+            key={chunk.id}
+            className="pl-6 border-l-2 border-white/10 text-white/70 leading-relaxed transition-colors"
+            initial={{ opacity: 0, x: -20 }}
+            animate={{ opacity: 1, x: 0 }}
+            transition={{ duration: 0.3, delay: idx * 0.05 }}
+          >
+            <span className="flex-1">{chunk.summary_text}</span>
+          </motion.div>
+        ))}
+    </div>
+  );
+}

--- a/components/search/UserProfile/CategoryList.tsx
+++ b/components/search/UserProfile/CategoryList.tsx
@@ -1,0 +1,21 @@
+import { CategorySection } from "./CategorySection";
+import type { ChunkData } from "@/components/profile/chunks/ChunkUtils";
+
+interface CategoryListProps {
+  groupedChunks: Record<string, ChunkData[]>;
+}
+
+export function CategoryList({ groupedChunks }: CategoryListProps) {
+  return (
+    <div className="space-y-6">
+      {Object.entries(groupedChunks).map(([category, categoryChunks], idx) => (
+        <CategorySection
+          key={category}
+          category={category}
+          chunks={categoryChunks}
+          index={idx}
+        />
+      ))}
+    </div>
+  );
+}

--- a/components/search/UserProfile/CategorySection.tsx
+++ b/components/search/UserProfile/CategorySection.tsx
@@ -1,0 +1,53 @@
+import { useState } from "react";
+import { ChevronDown } from "lucide-react";
+import { CategoryChunks } from "./CategoryChunks";
+import { motion } from "framer-motion";
+import type { ChunkData } from "@/components/profile/chunks/ChunkUtils";
+
+interface CategorySectionProps {
+  category: string;
+  index?: number;
+  chunks: ChunkData[];
+}
+
+export function CategorySection({
+  category,
+  index,
+  chunks,
+}: CategorySectionProps) {
+  const [expanded, setExpanded] = useState(false);
+
+  const handleToggle = () => setExpanded((prev) => !prev);
+
+  return (
+    <motion.div
+      className="relative"
+      initial={{ opacity: 0, y: 20 }}
+      animate={{ opacity: 1, y: 0 }}
+      transition={{ duration: 0.5, delay: index ? index * 0.25 : 0 }}
+    >
+      <div className="relative">
+        <motion.button
+          onClick={handleToggle}
+          className="w-full flex items-center justify-between py-2 hover:bg-white/5 transition-all rounded-lg group"
+          whileHover={{ x: 4 }}
+          whileTap={{ scale: 0.99 }}
+        >
+          <div className="flex items-center gap-4">
+            <h3 className="text-xl font-semibold text-white/90">{category}</h3>
+            <span className="text-sm text-white/50 bg-white/10 px-3 py-1 rounded-full">
+              {chunks.length}
+            </span>
+          </div>
+          <motion.div
+            animate={{ rotate: expanded ? 180 : 0 }}
+            transition={{ duration: 0.2 }}
+          >
+            <ChevronDown className="h-5 w-5 text-white/50 group-hover:text-white/70 transition-colors" />
+          </motion.div>
+        </motion.button>
+        {expanded && <CategoryChunks chunks={chunks} />}
+      </div>
+    </motion.div>
+  );
+}

--- a/components/search/UserProfile/ChunksList.tsx
+++ b/components/search/UserProfile/ChunksList.tsx
@@ -1,0 +1,40 @@
+import { CategoryList } from "./CategoryList";
+import type { ChunkData } from "@/components/profile/chunks/ChunkUtils";
+
+interface ChunksListProps {
+  chunks: ChunkData[];
+  chunksLoading?: boolean;
+}
+
+export function ChunksList({ chunks, chunksLoading }: ChunksListProps) {
+  if (chunksLoading) {
+    return (
+      <div className="text-white/40 text-sm text-center py-4">
+        Loading chunks...
+      </div>
+    );
+  }
+  if (!chunks || chunks.length === 0) {
+    return (
+      <div className="text-white/40 text-sm text-center py-4">
+        No chunks available.
+      </div>
+    );
+  }
+
+  // Group chunks by category
+  const groupedChunks = chunks.reduce<Record<string, ChunkData[]>>(
+    (acc, chunk) => {
+      const category =
+        chunk.category && chunk.category.trim() !== ""
+          ? chunk.category
+          : "General";
+      if (!acc[category]) acc[category] = [];
+      acc[category].push(chunk);
+      return acc;
+    },
+    {}
+  );
+
+  return <CategoryList groupedChunks={groupedChunks} />;
+}

--- a/components/search/UserProfile/UserProfile.tsx
+++ b/components/search/UserProfile/UserProfile.tsx
@@ -1,6 +1,8 @@
 import { AnimatePresence, motion } from "framer-motion";
 import { X } from "lucide-react";
 import Image from "next/image";
+import { ChunkData } from "@/components/profile/chunks/ChunkUtils";
+import { ChunksList } from "./ChunksList";
 
 export interface UserProfileProps {
   user: {
@@ -10,6 +12,8 @@ export interface UserProfileProps {
     status?: string;
     location?: string;
     tldr?: string;
+    chunks?: ChunkData[];
+    chunkLoading?: boolean;
   } | null;
   isOpen: boolean;
   onClose: () => void;
@@ -34,9 +38,9 @@ export const UserProfile = ({ user, isOpen, onClose }: UserProfileProps) => {
             animate={{ x: 0 }}
             exit={{ x: "100%" }}
             transition={{ type: "spring", damping: 25, stiffness: 200 }}
-            className="fixed right-0 top-0 h-full w-96 bg-[#0B0B0C]/95 backdrop-blur-xl border-l border-white/10 z-50 overflow-y-auto"
+            className="fixed right-0 top-0 h-full w-full max-w-4/5 md:w-[512px] bg-[#0B0B0C]/95 backdrop-blur-xl border-l border-white/10 z-50 overflow-y-auto"
           >
-            <div className="p-6">
+            <div className="p-4">
               <div className="flex items-center justify-between mb-6">
                 <div className="flex gap-3">
                   <button className="px-4 py-2 bg-white text-black rounded-xl font-medium hover:bg-white/90 transition-colors">
@@ -89,9 +93,15 @@ export const UserProfile = ({ user, isOpen, onClose }: UserProfileProps) => {
 
                 {/* Information tab placeholder - to be implemented later */}
                 <div className="pt-4 border-t border-white/10">
-                  <div className="text-white/40 text-sm text-center">
+                  {/* <div className="text-white/40 text-sm text-center">
                     More information coming soon...
-                  </div>
+                  </div> */}
+
+                  {/* Chunks List */}
+                  <ChunksList
+                    chunks={user.chunks || []}
+                    chunksLoading={user.chunkLoading || false}
+                  />
                 </div>
               </div>
             </div>

--- a/components/search/UserProfile/UserProfile.tsx
+++ b/components/search/UserProfile/UserProfile.tsx
@@ -3,6 +3,7 @@ import { X } from "lucide-react";
 import Image from "next/image";
 import { ChunkData } from "@/components/profile/chunks/ChunkUtils";
 import { ChunksList } from "./ChunksList";
+import { useEffect } from "react";
 
 export interface UserProfileProps {
   user: {
@@ -20,6 +21,20 @@ export interface UserProfileProps {
 }
 
 export const UserProfile = ({ user, isOpen, onClose }: UserProfileProps) => {
+  // On escape key press, close the profile
+  useEffect(() => {
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (event.key === "Escape") {
+        onClose();
+      }
+    };
+
+    window.addEventListener("keydown", handleKeyDown);
+    return () => {
+      window.removeEventListener("keydown", handleKeyDown);
+    };
+  }, [onClose]);
+
   if (!user) return null;
 
   return (


### PR DESCRIPTION
This pull request introduces a new user profile "chunks" feature, allowing users to view categorized summaries of their uploaded content within the profile sidebar. The implementation includes backend changes to enable chunk fetching, frontend state management for chunk loading, and several new React components for displaying chunk data in an organized, expandable format. Additionally, the codebase is refactored for clarity, including renaming and restructuring components related to user profiles and people lists.

**User Profile Chunks Feature**

* Added chunk data fetching in `SearchPageContent.tsx` using the authenticated request to `/api/profiles/getChunks`, and updated state to include `chunks` and `chunkLoading` for the selected user. [[1]](diffhunk://#diff-53f1b495cd40f656a3581661529b2960f8559d3195c138f01913e5cbbbf2c82fR49-R60) [[2]](diffhunk://#diff-53f1b495cd40f656a3581661529b2960f8559d3195c138f01913e5cbbbf2c82fL66-R103)
* Integrated new chunk display components: `ChunksList`, `CategoryList`, `CategorySection`, and `CategoryChunks` to render categorized and expandable chunk summaries in the user profile sidebar. [[1]](diffhunk://#diff-41b866d12711660c32123317d3010ccf549a95cc76f5d1d35bca0bb836f5178bR1-R40) [[2]](diffhunk://#diff-a73b92eff8cd5361e06fa4ef8d8a6f0a062887031f53b53ad40b069fd6099758R1-R21) [[3]](diffhunk://#diff-e9fd74ae2a81c2005ed3ed1e470ee759fc9d545882e72e36558e8635b36a77dfR1-R53) [[4]](diffhunk://#diff-78218669fcf9068dd5535e28d8c6fc1e4fd61466e683195cf7ad906d4e77a3ecR1-R26) [[5]](diffhunk://#diff-33c52af37a3ff1fa61132d01bfd0eb6e347d9b69fe5f1f910b2d043d1f321247L92-R119)

**Backend and API Adjustments**

* Removed the user ID authorization check from the `getChunks` API route, allowing chunk data to be fetched for any user (presumably for profile viewing purposes).

**Component Refactoring and Renaming**

* Renamed `PeopleSection` to `PeopleList` for clarity and updated all references and prop interfaces accordingly. [[1]](diffhunk://#diff-bc4e41e5016d0ac0d3371fd56e8086a9e95900e72209ecfb995a9e8fd8eb1ffeL6-R6) [[2]](diffhunk://#diff-bc4e41e5016d0ac0d3371fd56e8086a9e95900e72209ecfb995a9e8fd8eb1ffeL178-R178) [[3]](diffhunk://#diff-8ee1d429954aa5ef32901c0a7dca3a956ceeb5656309bb5b32cbb5036f58558eL6-R6) [[4]](diffhunk://#diff-8ee1d429954aa5ef32901c0a7dca3a956ceeb5656309bb5b32cbb5036f58558eL24-R28)
* Moved and renamed `UserProfile` component to `UserProfile/UserProfile.tsx` and updated its props to accept chunk data and loading state. Added escape key handling to close the profile sidebar. [[1]](diffhunk://#diff-53f1b495cd40f656a3581661529b2960f8559d3195c138f01913e5cbbbf2c82fL9-R14) [[2]](diffhunk://#diff-33c52af37a3ff1fa61132d01bfd0eb6e347d9b69fe5f1f910b2d043d1f321247R4-R6) [[3]](diffhunk://#diff-33c52af37a3ff1fa61132d01bfd0eb6e347d9b69fe5f1f910b2d043d1f321247R16-R37) [[4]](diffhunk://#diff-33c52af37a3ff1fa61132d01bfd0eb6e347d9b69fe5f1f910b2d043d1f321247L37-R58)

**UI/UX Improvements**

* Improved user profile sidebar responsiveness and layout, including width adjustments for better mobile and desktop support.
* Added loading and empty state indicators for chunk data in the profile sidebar.

**References:** [[1]](diffhunk://#diff-53f1b495cd40f656a3581661529b2960f8559d3195c138f01913e5cbbbf2c82fR49-R60) [[2]](diffhunk://#diff-53f1b495cd40f656a3581661529b2960f8559d3195c138f01913e5cbbbf2c82fL66-R103) [[3]](diffhunk://#diff-41b866d12711660c32123317d3010ccf549a95cc76f5d1d35bca0bb836f5178bR1-R40) [[4]](diffhunk://#diff-a73b92eff8cd5361e06fa4ef8d8a6f0a062887031f53b53ad40b069fd6099758R1-R21) [[5]](diffhunk://#diff-e9fd74ae2a81c2005ed3ed1e470ee759fc9d545882e72e36558e8635b36a77dfR1-R53) [[6]](diffhunk://#diff-78218669fcf9068dd5535e28d8c6fc1e4fd61466e683195cf7ad906d4e77a3ecR1-R26) [[7]](diffhunk://#diff-33c52af37a3ff1fa61132d01bfd0eb6e347d9b69fe5f1f910b2d043d1f321247L92-R119) [[8]](diffhunk://#diff-625de38ae1e27f9dc19a335d6297374db7b7830e6e721fe1cdfeda8eb3dd96d8L26-L32) [[9]](diffhunk://#diff-bc4e41e5016d0ac0d3371fd56e8086a9e95900e72209ecfb995a9e8fd8eb1ffeL6-R6) [[10]](diffhunk://#diff-bc4e41e5016d0ac0d3371fd56e8086a9e95900e72209ecfb995a9e8fd8eb1ffeL178-R178) [[11]](diffhunk://#diff-8ee1d429954aa5ef32901c0a7dca3a956ceeb5656309bb5b32cbb5036f58558eL6-R6) [[12]](diffhunk://#diff-8ee1d429954aa5ef32901c0a7dca3a956ceeb5656309bb5b32cbb5036f58558eL24-R28) [[13]](diffhunk://#diff-53f1b495cd40f656a3581661529b2960f8559d3195c138f01913e5cbbbf2c82fL9-R14) [[14]](diffhunk://#diff-33c52af37a3ff1fa61132d01bfd0eb6e347d9b69fe5f1f910b2d043d1f321247R4-R6) [[15]](diffhunk://#diff-33c52af37a3ff1fa61132d01bfd0eb6e347d9b69fe5f1f910b2d043d1f321247R16-R37) [[16]](diffhunk://#diff-33c52af37a3ff1fa61132d01bfd0eb6e347d9b69fe5f1f910b2d043d1f321247L37-R58)