### PR TITLE
Update avatar handling to use local placeholder; modify DSC established year to 'N/A'

### DIFF
--- a/components/clubs/ClubDetailPanel.tsx
+++ b/components/clubs/ClubDetailPanel.tsx
@@ -44,11 +44,7 @@ export function ClubDetailPanel({
             <div className="w-16 h-16 sm:w-20 sm:h-20 flex items-center justify-center">
               {club.logoUrl ? (
                 <Image
-                  src={
-                    club.logoUrl ||
-                    process.env.NEXT_PUBLIC_PLACEHOLDER_AVATAR_URL ||
-                    ""
-                  }
+                  src={club.logoUrl}
                   alt={`${club.name} logo`}
                   width={80}
                   height={80}

--- a/components/clubs/ClubsData.ts
+++ b/components/clubs/ClubsData.ts
@@ -113,7 +113,7 @@ export const clubsData: ClubData[] = [
       website: "https://www.dscuwa.com/",
       club: "https://www.uwastudentguild.com/clubs/data-science-club-of-uwa/",
     },
-    established: "2018",
+    established: "N/A",
     logoUrl:
       "https://nsjrzxbtxsqmsdgevszv.supabase.co/storage/v1/object/public/club_logos/uwa_dsc.png",
   },

--- a/components/search/PeopleList/ProfileCard.tsx
+++ b/components/search/PeopleList/ProfileCard.tsx
@@ -32,11 +32,7 @@ export const ProfileCard = ({ profile, index, onClick }: ProfileCardProps) => {
       >
         <div className="flex items-center gap-3 mb-3">
           <motion.img
-            src={
-              profile.avatar ||
-              process.env.NEXT_PUBLIC_PLACEHOLDER_AVATAR_URL ||
-              "/placeholder.png"
-            }
+            src={profile.avatar || "/placeholder.png"}
             alt={profile.name}
             className="h-12 w-12 rounded-full object-cover ring-2 ring-white/10"
             animate={{ scale: hovered ? 1.1 : 1 }}

--- a/components/search/hooks/useUserProfiles.ts
+++ b/components/search/hooks/useUserProfiles.ts
@@ -50,9 +50,7 @@ export function useUserProfiles(userIds: string[]) {
           status: profile.status,
           location: profile.location,
           tldr: profile.tldr,
-          avatar_url:
-            profile.avatar_url ||
-            process.env.NEXT_PUBLIC_PLACEHOLDER_AVATAR_URL,
+          avatar_url: profile.avatar_url || "/placeholder.png",
         });
       });
 

--- a/lib/supabase/storage.ts
+++ b/lib/supabase/storage.ts
@@ -103,7 +103,10 @@ export async function deleteAvatar(userId: string, supabase: SupabaseClient) {
     result.data.blurred_avatar_url
   );
 
-  if (avatarPath == process.env.NEXT_PUBLIC_PLACEHOLDER_AVATAR_URL) {
+  if (
+    avatarPath ==
+    `${process.env.NEXT_PUBLIC_URL}/storage/v1/object/public/avatars/placeholder_avatar.png`
+  ) {
     console.log("Placeholder avatar detected, skipping deletion.");
     return { success: true };
   }

--- a/lib/users/fetchUserDetails.ts
+++ b/lib/users/fetchUserDetails.ts
@@ -65,8 +65,7 @@ export async function fetchMultipleUsers(
       userMap.set(user.id, {
         id: user.id,
         full_name: `${user.first_name} ${user.last_name}`,
-        avatar_url:
-          user.avatar_url || process.env.NEXT_PUBLIC_PLACEHOLDER_AVATAR_URL,
+        avatar_url: user.avatar_url || "/placeholder.png",
       });
     });
 


### PR DESCRIPTION
…
This pull request standardizes the handling of placeholder avatar images across the codebase by replacing environment variable references with a consistent static path. It also updates club data to reflect missing establishment information. The most important changes are grouped below.

**Avatar and Image Handling Improvements:**

* Replaced references to `process.env.NEXT_PUBLIC_PLACEHOLDER_AVATAR_URL` with the static path `"/placeholder.png"` in `ProfileCard.tsx`, `useUserProfiles.ts`, and `fetchUserDetails.ts` to ensure consistent fallback behavior for missing avatars. [[1]](diffhunk://#diff-3b9ac23aa287bd52d6cc3c0b51e72be4f8a8fdaef2e0f717b50d54bea0326d8dL35-R35) [[2]](diffhunk://#diff-aab8f8b3bfa4b87cc2230cc850c9a9d3eeb9c309946e0b1caea263d391bc83dcL53-R53) [[3]](diffhunk://#diff-949c90216360bd2545063f250df02ae71106250170524645207708744550e092L68-R68)
* Updated the avatar deletion logic in `storage.ts` to check for the full static placeholder path instead of the environment variable, preventing unnecessary deletion attempts for placeholder avatars.
* Simplified the `ClubDetailPanel.tsx` image source logic by removing the fallback to the environment variable, now using only the club's logo URL.

**Club Data Update:**

* Changed the `established` field for the Data Science Club of UWA in `ClubsData.ts` from `"2018"` to `"N/A"` to reflect missing information.